### PR TITLE
Minor Removal

### DIFF
--- a/Stormpath/Networking/Logger.swift
+++ b/Stormpath/Networking/Logger.swift
@@ -22,9 +22,7 @@ final class Logger {
     static var logLevel: LogLevel {
         if _isDebugAssertConfiguration() {
             return .Debug
-        } else {
-            return .None
-        }
+        } 
     }
     
     class func log(string: String) {


### PR DESCRIPTION
If I understand the code correctly, `if _isDebugAssertConfiguration()` should _always_ execute. Minor, but cleaner.
